### PR TITLE
[Refactor] API 응답 일관성 보완

### DIFF
--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/controller/CommentController.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/controller/CommentController.java
@@ -6,10 +6,10 @@ import hanshin.home_risk_check.community.service.CommentService;
 import hanshin.home_risk_check.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal; // [변경] 현재 로그인 사용자 이메일 주입을 위해 추가
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /*
  * 댓글 Controller
@@ -22,12 +22,16 @@ public class CommentController {
     private final CommentService commentService;
 
     /*
-     * 댓글 목록 조회
-     * GET /api/posts/{postId}/comments
+     * 댓글 목록 조회 (pagination)
+     * GET /api/posts/{postId}/comments?page=0&size=20
      */
     @GetMapping("/posts/{postId}/comments")
-    public ApiResponse<List<CommentResponse>> getComments(@PathVariable Long postId) {
-        return ApiResponse.success(commentService.getComments(postId));
+    public ApiResponse<Page<CommentResponse>> getComments(
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponse.success(commentService.getComments(postId, page, size));
     }
 
     /*
@@ -35,18 +39,14 @@ public class CommentController {
      * POST /api/posts/{postId}/comments
      */
     @PostMapping("/posts/{postId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<CommentResponse> createComment(
             @PathVariable Long postId,
-            @AuthenticationPrincipal String email, // [변경] JWT Filter에서 principal로 넣은 email 사용
+            @AuthenticationPrincipal String email,
             @Valid @RequestBody CommentCreateRequest request
     ) {
-        /*
-         * [변경]
-         * 기존 Long authorId = 1L 제거
-         * Service에서 email로 User를 조회해 작성자로 사용
-         */
         return ApiResponse.success(
-                201,
+                HttpStatus.CREATED.value(),
                 "댓글 작성 성공",
                 commentService.createComment(postId, email, request)
         );
@@ -59,14 +59,9 @@ public class CommentController {
     @DeleteMapping("/comments/{commentId}")
     public ApiResponse<Void> deleteComment(
             @PathVariable Long commentId,
-            @AuthenticationPrincipal String email // [변경]
+            @AuthenticationPrincipal String email
     ) {
-        /*
-         * [변경]
-         * 기존 Long authorId = 1L 제거
-         */
         commentService.deleteComment(commentId, email);
-
-        return ApiResponse.success(200, "댓글 삭제 성공", null);
+        return ApiResponse.success(HttpStatus.OK.value(), "댓글 삭제 성공", null);
     }
 }

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/controller/PostController.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/controller/PostController.java
@@ -7,11 +7,12 @@ import hanshin.home_risk_check.community.dto.PostUpdateRequest;
 import hanshin.home_risk_check.community.service.PostImageService;
 import hanshin.home_risk_check.community.service.PostService;
 import hanshin.home_risk_check.global.dto.ApiResponse;
-import jakarta.validation.Valid; // [변경] DTO Bean Validation 적용을 위해 추가
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.annotation.AuthenticationPrincipal; // [변경] 현재 로그인 사용자 이메일 주입을 위해 추가
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -43,17 +44,13 @@ public class PostController {
     }
 
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<PostResponse> createPost(
-            @AuthenticationPrincipal String email, // [변경] JWT Filter에서 principal로 넣은 email 사용
-            @Valid @RequestBody PostCreateRequest request // [변경] DTO Validation 적용
+            @AuthenticationPrincipal String email,
+            @Valid @RequestBody PostCreateRequest request
     ) {
-        /*
-         * [변경]
-         * 기존 Long authorId = 1L 제거
-         * Service에서 email로 User를 조회해 작성자로 사용
-         */
         return ApiResponse.success(
-                201,
+                HttpStatus.CREATED.value(),
                 "게시글 작성 성공",
                 postService.createPost(email, request)
         );
@@ -62,13 +59,9 @@ public class PostController {
     @PatchMapping("/{postId}")
     public ApiResponse<PostResponse> updatePost(
             @PathVariable Long postId,
-            @AuthenticationPrincipal String email, // [변경]
-            @Valid @RequestBody PostUpdateRequest request // [변경] DTO Validation 적용
+            @AuthenticationPrincipal String email,
+            @Valid @RequestBody PostUpdateRequest request
     ) {
-        /*
-         * [변경]
-         * 기존 Long authorId = 1L 제거
-         */
         return ApiResponse.success(
                 postService.updatePost(postId, email, request)
         );
@@ -77,15 +70,10 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ApiResponse<Void> deletePost(
             @PathVariable Long postId,
-            @AuthenticationPrincipal String email // [변경]
+            @AuthenticationPrincipal String email
     ) {
-        /*
-         * [변경]
-         * 기존 Long authorId = 1L 제거
-         */
         postService.deletePost(postId, email);
-
-        return ApiResponse.success(200, "게시글 삭제 성공", null);
+        return ApiResponse.success(HttpStatus.OK.value(), "게시글 삭제 성공", null);
     }
 
     /*
@@ -93,12 +81,13 @@ public class PostController {
      * 게시글 1개당 최대 10장
      */
     @PostMapping(value = "/{postId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<List<PostImageResponse>> uploadPostImages(
             @PathVariable Long postId,
             @RequestPart("images") List<MultipartFile> images
     ) {
         return ApiResponse.success(
-                201,
+                HttpStatus.CREATED.value(),
                 "게시글 이미지 업로드 성공",
                 postImageService.uploadPostImages(postId, images)
         );
@@ -121,7 +110,6 @@ public class PostController {
             @PathVariable Long postImageId
     ) {
         postImageService.deletePostImage(postId, postImageId);
-
-        return ApiResponse.success(200, "게시글 이미지 삭제 성공", null);
+        return ApiResponse.success(HttpStatus.OK.value(), "게시글 이미지 삭제 성공", null);
     }
 }

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/repository/CommentRepository.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/repository/CommentRepository.java
@@ -1,27 +1,26 @@
 package hanshin.home_risk_check.community.repository;
 
 import hanshin.home_risk_check.community.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 /*
  * 댓글 Repository
- * DB의 comment 테이블에 접근하는 인터페이스
  */
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     /*
-     * 특정 게시글의 댓글 전체 조회
-     *
-     * 연관관계 매핑 기준:
-     * - post.postId 로 조건 조회
-     * - rootComment.commentId -> depth -> createdAt 순으로 정렬
-     *
-     * 정렬 목적:
-     * 1. 같은 루트 댓글 그룹끼리 묶기
-     * 2. 댓글(0) -> 대댓글(1) 순 유지
-     * 3. 같은 depth 안에서는 작성 시간 순 정렬
+     * 특정 게시글의 댓글 전체 조회 (정렬 메서드명 기반)
+     * - rootComment.commentId -> depth -> createdAt 순 정렬
      */
     List<Comment> findAllByPost_PostIdOrderByRootComment_CommentIdAscDepthAscCreatedAtAsc(Long postId);
+
+    /*
+     * 특정 게시글의 댓글 페이지 조회
+     * 정렬은 호출자가 Pageable의 Sort로 지정.
+     */
+    Page<Comment> findByPost_PostId(Long postId, Pageable pageable);
 }

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/service/CommentService.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/community/service/CommentService.java
@@ -8,13 +8,15 @@ import hanshin.home_risk_check.community.repository.CommentRepository;
 import hanshin.home_risk_check.community.repository.PostRepository;
 import hanshin.home_risk_check.global.exception.BusinessException;
 import hanshin.home_risk_check.global.exception.ErrorCode;
-import hanshin.home_risk_check.user.entity.User; // [변경] 작성자 User 사용
-import hanshin.home_risk_check.user.repository.UserRepository; // [변경] email로 User 조회
+import hanshin.home_risk_check.user.entity.User;
+import hanshin.home_risk_check.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 /*
  * 댓글 Service
@@ -29,16 +31,20 @@ public class CommentService {
     private final UserRepository userRepository; // [변경] 로그인 사용자 조회용 Repository 추가
 
     /*
-     * 특정 게시글의 댓글 목록 조회
+     * 특정 게시글의 댓글 목록 조회 (페이지네이션)
+     * 정렬: rootComment.commentId ASC, depth ASC, createdAt ASC
      */
-    public List<CommentResponse> getComments(Long postId) {
+    public Page<CommentResponse> getComments(Long postId, int page, int size) {
         validatePostExists(postId);
 
-        return commentRepository
-                .findAllByPost_PostIdOrderByRootComment_CommentIdAscDepthAscCreatedAtAsc(postId)
-                .stream()
-                .map(CommentResponse::from)
-                .toList();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(
+                Sort.Order.asc("rootComment.commentId"),
+                Sort.Order.asc("depth"),
+                Sort.Order.asc("createdAt")
+        ));
+
+        return commentRepository.findByPost_PostId(postId, pageable)
+                .map(CommentResponse::from);
     }
 
     /*

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/user/controller/UserController.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/user/controller/UserController.java
@@ -6,13 +6,18 @@ import hanshin.home_risk_check.user.dto.LoginResponse;
 import hanshin.home_risk_check.user.dto.SignupRequest;
 import hanshin.home_risk_check.user.dto.UserResponse;
 import hanshin.home_risk_check.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/auth")
 public class UserController {
 
     private final UserService userService;
@@ -23,16 +28,16 @@ public class UserController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponse>> signup(@RequestBody SignupRequest request) {
+    public ResponseEntity<ApiResponse<UserResponse>> signup(@Valid @RequestBody SignupRequest request) {
         UserResponse response = userService.signup(request);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED.value(), "회원 가입 성공", response));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
-
-    //회원 조회, 정보 수정, 비밀번호 변경 등 추가적인 엔드포인트 구현 예정
 }


### PR DESCRIPTION
<!-- 템플릿 설명
1. Pull Request 템플릿의 제목은 다음과 같이 작성합니다.
예시) [Feature] 로그인 구현

2. (내용) 부분을 수정 또는 추가해 주세요.
-->

<!-- 작업한 기능에 대한 간단한 설명을 작성해주세요. -->
🔎 개요
- API 응답 일관성 보완

<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
📑 작업 내용
- UserController
    - signup HTTP 201 + Valid 적용
 - PostController
     - 200/201 매직 넘버 → HttpStatus.OK.value() / HttpStatus.CREATED.value()
     - createPost, uploadPostImages에 @ResponseStatus(HttpStatus.CREATED) 적용 → ApiResponse code와 HTTP 상태 일치
 - CommentController
     - createComment에 @ResponseStatus(HttpStatus.CREATED)
     - getComments에 페이지네이션 파라미터 (page, size) 도입, Page<CommentResponse> 반환
     - Page 호환 가능하도록 CommentService, CommentRepository 수정 

<!-- 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
‼️ 기타 사항
- 모든 API 응답은 커스텀 객체 대신 ResponseEntity<> 반환하도록 하는 것을 검토

✅ 체크 사항
- [x] 빌드/실행 확인
- [x] 민감 정보 제거
- [x] 테스트 코드 작성 및 통과
- [x] 컨벤션 준수

<!-- 작업한 기능과 관련된 이슈가 있다면 작성해주세요.
해당 pr merge 시 이슈 close
-->
📎 관련 이슈
- closes #이슈번호