### PR TITLE
[Refactor] HUG·현실화율 배수 정책 외부화

### DIFF
--- a/backend/home-risk-check-fastapi/app/core/policy_config.py
+++ b/backend/home-risk-check-fastapi/app/core/policy_config.py
@@ -1,0 +1,135 @@
+"""
+HUG·공시가격 현실화율 정책 이력 관리
+
+담당 기능:
+- HUG 보증보험 공시가 배수 (적용일자 기준 조회)
+- 공시가격 현실화율 기반 시세 추정 배수 (건물유형 + 적용일자)
+
+[설계 원칙]
+- 정책 이력은 코드에 명시적으로 기록 (git history로 추적 가능)
+- DB 의존성 없음 (변경 빈도 낮음, 정책은 정적 데이터)
+- 적용일자 기준 조회로 과거 시점 분석 가능 (계약일 기준 등)
+
+[근거 문서]
+- HUG: 「전세보증금반환보증 운영지침」
+- 현실화율: 국토교통부 「부동산 공시가격 현실화 계획」 (2020.11.03)
+  2023~2026년 4년 연속 동결 (2025.11.13 중앙부동산가격공시위원회 심의·의결)
+  https://www.korea.kr/news/policyNewsView.do?newsId=148879449
+"""
+from datetime import date
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+
+# =============================================================================
+# 1. HUG 공시가 배수 정책
+# =============================================================================
+class HugPolicy(NamedTuple):
+    """HUG 보증보험 한도 산정용 공시가 배수 정책 한 건"""
+    public_price_multiplier: float    # 공시가 × N = HUG 한도
+    effective_from: date              # 적용 시작일 (포함)
+    effective_to: Optional[date]      # 적용 종료일 (포함). None = 현재 유효
+    source: str                       # 근거 (지침명·개정일)
+
+
+# 신규 정책이 위에 오도록 정렬 (조회 시 첫 매치 반환)
+HUG_POLICY_HISTORY: List[HugPolicy] = [
+    HugPolicy(
+        public_price_multiplier=1.26,           # 공시가 × 140% × 90%
+        effective_from=date(2023, 5, 1),
+        effective_to=None,
+        source="HUG 전세보증금반환보증 운영지침 (2023.05.01 개정)",
+    ),
+    HugPolicy(
+        public_price_multiplier=1.50,           # 공시가 × 150% × 100% (구 기준)
+        effective_from=date(2017, 1, 1),
+        effective_to=date(2023, 4, 30),
+        source="HUG 전세보증금반환보증 운영지침 (구 기준, ~2023.04.30)",
+    ),
+]
+
+
+def get_hug_multiplier(at: Optional[date] = None) -> Tuple[float, str]:
+    """
+    주어진 시점에 적용되는 HUG 공시가 배수 반환.
+
+    Args:
+        at: 기준 일자. None이면 오늘 날짜 사용.
+
+    Returns:
+        (배수, 근거) 튜플
+
+    Raises:
+        ValueError: 해당 시점에 적용되는 정책이 없는 경우
+    """
+    target = at or date.today()
+    for policy in HUG_POLICY_HISTORY:
+        if policy.effective_from <= target and (
+            policy.effective_to is None or target <= policy.effective_to
+        ):
+            return policy.public_price_multiplier, policy.source
+    raise ValueError(f"{target}에 적용되는 HUG 정책이 없습니다")
+
+
+# =============================================================================
+# 2. 공시가격 현실화율 기반 배수 정책
+# =============================================================================
+class RealizationPolicy(NamedTuple):
+    """공시가→시세 추정용 배수 정책 한 건"""
+    multipliers_by_keyword: Dict[str, float]   # 건물유형 키워드 → 배수
+    default_multiplier: float                   # 매칭 실패 시 기본값
+    effective_from: date
+    effective_to: Optional[date]
+    source: str
+
+
+# 2023~2026년 동결 정책 적용
+# - 공동주택 현실화율 69.0% → 1/0.69 = 1.449
+# - 단독주택 현실화율 53.6% → 1/0.536 = 1.866
+# - 오피스텔은 국세청 기준시가로 별도 관리되나, 공동주택과 유사 분포로 1.449 적용
+REALIZATION_POLICY_HISTORY: List[RealizationPolicy] = [
+    RealizationPolicy(
+        multipliers_by_keyword={
+            "아파트":    1.449,    # 공동주택 69.0%
+            "연립":      1.449,
+            "다세대":    1.449,
+            "오피스텔":  1.449,
+            "단독":      1.866,    # 단독주택 53.6%
+            "다가구":    1.866,
+        },
+        default_multiplier=1.449,   # 가장 보수적(시세 낮게 추정) = 공동주택 기준
+        effective_from=date(2023, 1, 1),
+        effective_to=None,           # 2026년까지 동결 확정 (2025.11.13 심의)
+        source="국토부 부동산 공시가격 현실화 계획 동결 (2023~2026)",
+    ),
+]
+
+
+def get_realization_multiplier(
+        building_type: str,
+        at: Optional[date] = None,
+) -> Tuple[float, str]:
+    """
+    건물유형 + 적용일자 기준 공시가→시세 변환 배수 반환.
+
+    Args:
+        building_type: 주용도 (예: "다세대주택", "아파트", "오피스텔")
+        at: 기준 일자. None이면 오늘 날짜 사용.
+
+    Returns:
+        (배수, 매칭된 키워드 또는 "기본값(공동주택)") 튜플
+
+    Raises:
+        ValueError: 해당 시점에 적용되는 정책이 없는 경우
+    """
+    target = at or date.today()
+    for policy in REALIZATION_POLICY_HISTORY:
+        if policy.effective_from <= target and (
+            policy.effective_to is None or target <= policy.effective_to
+        ):
+            if not building_type:
+                return policy.default_multiplier, "기본값(공동주택)"
+            for keyword, multiplier in policy.multipliers_by_keyword.items():
+                if keyword in building_type:
+                    return multiplier, keyword
+            return policy.default_multiplier, "기본값(공동주택)"
+    raise ValueError(f"{target}에 적용되는 현실화율 정책이 없습니다")

--- a/backend/home-risk-check-fastapi/app/services/predict_service.py
+++ b/backend/home-risk-check-fastapi/app/services/predict_service.py
@@ -19,6 +19,9 @@
   - 변경: calculate_hybrid_score(features) → 룰 60% + ML 40% 결합 점수
 - [NEW] estimate_market_price 호출 시 building_type 전달
   - 공시가 fallback 시 국토부 현실화율 기반 유형별 배수 적용
+- [REFACTOR] hug_risk_ratio 중복 계산 제거
+  - build_features_from_sources에서 이미 동일하게 계산되던 죽은 코드 제거
+  - HUG 배수는 app.core.policy_config 에서 단일 관리
 """
 import logging
 from datetime import datetime
@@ -222,10 +225,6 @@ def predict_risk_with_ocr(
             public_price_won=public_price,
             ocr_features=ocr_features
         )
-
-        # HUG 위험 비율 업데이트 (실제 공시가 기반)
-        if public_price > 0:
-            features['hug_risk_ratio'] = (deposit_manwon * 10000) / (public_price * 1.26)
 
         # 5. [변경] 하이브리드 판정 (룰 베이스 60% + ML 40%)
         hybrid = calculate_hybrid_score(features)

--- a/backend/home-risk-check-fastapi/app/services/price_service.py
+++ b/backend/home-risk-check-fastapi/app/services/price_service.py
@@ -8,14 +8,13 @@
 - 시세 추정 로직
 
 [변경 이력]
-- [NEW] 공시가 → 시세 추정 시 국토부 현실화율 기반 유형별 배수 적용
-  - 기존: 일괄 × 1.26 (HUG 기준)
-  - 변경: 공동주택 × 1.449, 단독주택 × 1.866, 오피스텔 × 1.587
-  - 근거: 국토교통부 "부동산 공시가격 현실화 계획" (2020.11.03)
-         2023~2026년 4년 연속 동결 (2025.11.13 중앙부동산가격공시위원회 확인)
+- [REFACTOR] HUG·현실화 배수 외부화
+  - REALIZATION_MULTIPLIER, DEFAULT_MULTIPLIER, _get_realization_multiplier 제거
+  - calculate_hug_eligibility의 1.26 하드코딩 제거
+  - 모든 정책 조회를 app.core.policy_config로 위임 (적용일자 지원)
 """
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Tuple, Optional
 
 from sqlalchemy import text
@@ -23,57 +22,16 @@ from sqlalchemy.exc import OperationalError
 
 from app.core import get_engine, is_db_available
 from app.core.exceptions import DatabaseConnectionError
+from app.core.policy_config import (
+    get_hug_multiplier,
+    get_realization_multiplier,
+)
 from app.services.address_service import parse_pnu, pnu_to_raw_format
 
 logger = logging.getLogger(__name__)
 
 # 재시도 설정
-MAX_DB_RETRIES=2
-
-
-# =============================================================================
-# 공시가격 → 시세 추정 배수 (국토부 현실화율 기반)
-# =============================================================================
-# 근거: 국토교통부·행정안전부, "부동산 공시가격 현실화 계획" (2020.11.03)
-#       대한민국 정책브리핑 https://www.korea.kr/news/policyNewsView.do?newsId=148879449
-#       국토교통부 보도자료 https://www.molit.go.kr/USR/NEWS/m_71/dtl.jsp?lcmspage=94&id=95089062
-#       - 공동주택 현실화율 69.0% → 배수 1/0.69 = 1.449
-#       - 단독주택 현실화율 53.6% → 배수 1/0.536 = 1.866
-#       - 토지     현실화율 65.5% → 배수 1/0.655 = 1.527
-#       2023년 이후 4년 연속 동결 (2025.11.13 중앙부동산가격공시위원회 심의·의결)
-#
-# 오피스텔은 공동주택에 포함되지 않으며 국세청 기준시가로 별도 관리됨.
-# 공동주택(69%)과 단독주택(53.6%) 중간값인 약 63%를 추정 적용.
-# =============================================================================
-REALIZATION_MULTIPLIER = {
-    "아파트":     1.449,   # 공동주택 69.0%
-    "연립":       1.449,   # 공동주택 69.0%
-    "다세대":     1.449,   # 공동주택 69.0%
-    "단독":       1.866,   # 단독주택 53.6%
-    "다가구":     1.866,   # 단독주택 53.6%
-    "오피스텔":   1.449,   # 공동주택 69.0%
-}
-DEFAULT_MULTIPLIER = 1.449  # 공동주택 기준 (가장 보수적)
-
-
-def _get_realization_multiplier(building_type: str) -> Tuple[float, str]:
-    """
-    건물 유형별 공시가→시세 변환 배수 반환 (국토부 현실화율 기반)
-
-    Args:
-        building_type: 주용도 (예: "다세대주택", "아파트", "오피스텔")
-
-    Returns:
-        Tuple[배수, 매칭된 유형명]
-    """
-    if not building_type:
-        return DEFAULT_MULTIPLIER, "기본값(공동주택)"
-
-    for keyword, multiplier in REALIZATION_MULTIPLIER.items():
-        if keyword in building_type:
-            return multiplier, keyword
-
-    return DEFAULT_MULTIPLIER, "기본값(공동주택)"
+MAX_DB_RETRIES = 2
 
 
 def _execute_query_safe(query, params: dict = None, operation_name: str = "DB 작업"):
@@ -525,7 +483,7 @@ def estimate_market_price(
     public_price = get_public_price(pnu, area_size)
 
     if public_price > 0:
-        multiplier, matched_type = _get_realization_multiplier(building_type)
+        multiplier, matched_type = get_realization_multiplier(building_type)
         estimated = (public_price / 10000) * multiplier
         logger.info(
             f"공시지가 기반 시세 추정: {estimated:,.0f}만원 "
@@ -538,7 +496,8 @@ def estimate_market_price(
 
 def calculate_hug_eligibility(
         public_price: float,
-        deposit_manwon: float
+        deposit_manwon: float,
+        contract_date: Optional[date] = None,
 ) -> Tuple[bool, float, str]:
     """
     HUG 보증보험 가입 가능 여부 판단
@@ -546,6 +505,7 @@ def calculate_hug_eligibility(
     Args:
         public_price: 공시가격 (원)
         deposit_manwon: 보증금 (만원)
+        contract_date: 계약 기준일 (None이면 오늘 정책 적용)
 
     Returns:
         Tuple[가입가능여부, HUG한도(만원), 메시지]
@@ -553,8 +513,9 @@ def calculate_hug_eligibility(
     if public_price <= 0:
         return False, 0, "공시가 없음 (판단 불가)"
 
-    # HUG 한도 = 공시가 × 126%
-    hug_limit_won = public_price * 1.26
+    # 적용 시점의 HUG 공시가 배수 조회 (정책 이력 기반)
+    multiplier, _source = get_hug_multiplier(contract_date)
+    hug_limit_won = public_price * multiplier
     hug_limit_manwon = hug_limit_won / 10000
 
     if deposit_manwon <= hug_limit_manwon:

--- a/backend/home-risk-check-fastapi/app/services/risk_calculator.py
+++ b/backend/home-risk-check-fastapi/app/services/risk_calculator.py
@@ -31,6 +31,9 @@ from app.services.feature_service import (
     TRAIN_FEATURES,
 )
 
+# HUG 정책 (적용일자 기반 배수 조회)
+from app.core.policy_config import get_hug_multiplier
+
 logger = logging.getLogger(__name__)
 
 # 프로젝트 루트
@@ -154,8 +157,11 @@ def build_features_from_sources(
     # --- 3. predict_service가 필요로 하는 추가 키 보강 ---
     # 공시가 기반 HUG 위험 비율 (실제 공시가가 있는 경우 덮어쓰기)
     if public_price_won > 0:
-        hug_limit_manwon = (public_price_won * 1.26) / 10000
-        features['_ref_hug_risk_ratio'] = deposit_manwon / hug_limit_manwon if hug_limit_manwon > 0 else 0
+        hug_multiplier, _ = get_hug_multiplier()
+        hug_limit_manwon = (public_price_won * hug_multiplier) / 10000
+        features['_ref_hug_risk_ratio'] = (
+            deposit_manwon / hug_limit_manwon if hug_limit_manwon > 0 else 0
+        )
 
     # predict_service에서 사용하는 레거시 키 호환
     # (analyze_risk_factors, API 응답 등에서 참조)

--- a/backend/home-risk-check-fastapi/tests/test_realization_rate.py
+++ b/backend/home-risk-check-fastapi/tests/test_realization_rate.py
@@ -2,26 +2,37 @@
 공시가격 현실화율 기반 시세 추정 배수 테스트
 
 테스트 항목:
-1. _get_realization_multiplier(): 건물 유형별 배수 매칭 정확성
+1. get_realization_multiplier(): 건물 유형별 배수 매칭 정확성 (정책 모듈 직접 테스트)
 2. estimate_market_price(): 공시가 fallback 시 유형별 배수 적용 검증
 3. predict_service 통합: building_type이 estimate_market_price에 전달되는지 검증
+4. 현실화율 배수 값 정확성 검증
+5. 정책 이력 자체 검증 (시간 갭/중복, 적용일자 기반 조회)
 
 근거: 국토교통부 "'24년 현실화율, 올해와 동일하게 동결" (2023.11.21)
       공동주택 69.0%, 단독주택 53.6%, 토지 65.5%
+
+[변경 이력]
+- 정책 외부화에 따라 import 경로 갱신
+  - app.services.price_service._get_realization_multiplier
+    → app.core.policy_config.get_realization_multiplier
+  - REALIZATION_MULTIPLIER, DEFAULT_MULTIPLIER 직접 참조 제거
+- 정책 이력 일관성 검증 테스트(TestPolicyHistoryConsistency) 추가
 """
+from datetime import date, timedelta
+
 import pytest
 from unittest.mock import patch, MagicMock
 
 
 # =============================================================================
-# 1. _get_realization_multiplier 단위 테스트
+# 1. get_realization_multiplier 단위 테스트
 # =============================================================================
 class TestGetRealizationMultiplier:
     """건물 유형별 배수 매칭 검증"""
 
     def _get_fn(self):
-        from app.services.price_service import _get_realization_multiplier
-        return _get_realization_multiplier
+        from app.core.policy_config import get_realization_multiplier
+        return get_realization_multiplier
 
     # --- 공동주택 (69.0% → 1.449) ---
 
@@ -314,6 +325,84 @@ class TestRealizationMultiplierValues:
 
     def test_default_multiplier_is_most_conservative(self):
         """기본값은 가장 보수적(시세 낮게 추정)인 공동주택 배수"""
-        from app.services.price_service import DEFAULT_MULTIPLIER, REALIZATION_MULTIPLIER
-        all_multipliers = list(REALIZATION_MULTIPLIER.values())
-        assert DEFAULT_MULTIPLIER == min(all_multipliers)
+        from app.core.policy_config import REALIZATION_POLICY_HISTORY
+
+        current_policy = REALIZATION_POLICY_HISTORY[0]   # 최신 정책
+        all_multipliers = list(current_policy.multipliers_by_keyword.values())
+        assert current_policy.default_multiplier == min(all_multipliers)
+
+
+# =============================================================================
+# 5. 정책 이력 자체 검증 (신규)
+# =============================================================================
+class TestPolicyHistoryConsistency:
+    """정책 이력의 시간 순서·중복·범위 검증"""
+
+    # --- HUG 정책 ---
+
+    def test_hug_history_has_no_gaps_or_overlaps(self):
+        """HUG 정책 이력에 시간 갭이나 중복이 없어야 함"""
+        from app.core.policy_config import HUG_POLICY_HISTORY
+
+        # 시간순 정렬 (오래된 것부터)
+        sorted_policies = sorted(HUG_POLICY_HISTORY, key=lambda p: p.effective_from)
+        for prev, curr in zip(sorted_policies, sorted_policies[1:]):
+            assert prev.effective_to is not None, \
+                f"중간 정책의 effective_to는 필수: {prev.source}"
+            assert prev.effective_to + timedelta(days=1) == curr.effective_from, \
+                f"정책 갭/중복 발견: {prev.source} → {curr.source}"
+
+    def test_hug_only_latest_policy_has_open_end(self):
+        """현재 유효 HUG 정책(effective_to=None)은 정확히 1개여야 함"""
+        from app.core.policy_config import HUG_POLICY_HISTORY
+
+        open_ended = [p for p in HUG_POLICY_HISTORY if p.effective_to is None]
+        assert len(open_ended) == 1
+
+    def test_hug_lookup_for_today_returns_current_policy(self):
+        """오늘 날짜 조회 시 현재 정책(1.26) 반환"""
+        from app.core.policy_config import get_hug_multiplier
+
+        multiplier, source = get_hug_multiplier()
+        assert multiplier == 1.26
+        assert "2023" in source
+
+    def test_hug_lookup_for_legacy_date_returns_legacy_policy(self):
+        """2020년 시점 조회 시 구 정책(1.50) 반환"""
+        from app.core.policy_config import get_hug_multiplier
+
+        multiplier, source = get_hug_multiplier(at=date(2020, 1, 1))
+        assert multiplier == 1.50
+        assert "구 기준" in source
+
+    def test_hug_lookup_for_unmodeled_date_raises(self):
+        """모델링되지 않은 과거 날짜는 ValueError 발생 (silent fallback 금지)"""
+        from app.core.policy_config import get_hug_multiplier
+
+        with pytest.raises(ValueError):
+            get_hug_multiplier(at=date(2000, 1, 1))
+
+    # --- 현실화율 정책 ---
+
+    def test_realization_only_latest_policy_has_open_end(self):
+        """현재 유효 현실화율 정책(effective_to=None)은 정확히 1개여야 함"""
+        from app.core.policy_config import REALIZATION_POLICY_HISTORY
+
+        open_ended = [p for p in REALIZATION_POLICY_HISTORY if p.effective_to is None]
+        assert len(open_ended) == 1
+
+    def test_realization_lookup_for_unmodeled_date_raises(self):
+        """모델링되지 않은 과거 날짜는 ValueError 발생"""
+        from app.core.policy_config import get_realization_multiplier
+
+        with pytest.raises(ValueError):
+            get_realization_multiplier("아파트", at=date(2000, 1, 1))
+
+    def test_realization_default_is_min_of_keyword_multipliers(self):
+        """default_multiplier는 정책 내 최소 배수와 같아야 (보수적 기본값)"""
+        from app.core.policy_config import REALIZATION_POLICY_HISTORY
+
+        for policy in REALIZATION_POLICY_HISTORY:
+            min_keyword = min(policy.multipliers_by_keyword.values())
+            assert policy.default_multiplier == min_keyword, \
+                f"정책 default_multiplier가 키워드 최소값과 다름: {policy.source}"


### PR DESCRIPTION
## 🔎 개요
- 코드 곳곳에 흩어져 있던 HUG 공시가 배수(1.26)와 현실화율 배수 매핑을 `app/core/policy_config.py`로 단일화
- 적용일자 기준 정책 조회 구조로 변경하여 향후 정책 개정 시 한 곳만 수정하면 되도록 정리

## 📑 작업 내용
- `app/core/policy_config.py` 신설
  - `HugPolicy`, `RealizationPolicy` NamedTuple로 정책 이력 모델링
  - `get_hug_multiplier(at)`, `get_realization_multiplier(building_type, at)` 적용일자 기준 조회 API
  - 정책 이력 명시: HUG `1.50 (~2023.04.30)` → `1.26 (2023.05.01~)`, 현실화율 `2023~2026 동결`
- `price_service.py` 정리
  - `REALIZATION_MULTIPLIER` / `DEFAULT_MULTIPLIER` / `_get_realization_multiplier` 제거 → `policy_config` 위임
  - `calculate_hug_eligibility`의 `* 1.26` 하드코딩 제거, `contract_date` 인자 추가 (기본값 오늘)
- `risk_calculator.py`의 `* 1.26` 하드코딩 제거 → `get_hug_multiplier()` 사용
- `predict_service.py`의 `hug_risk_ratio` 중복 계산 제거
  - `build_features_from_sources`에서 이미 동일 식으로 계산되던 죽은 코드였음
- `test_realization_rate.py` 임포트 경로 갱신 + 정책 이력 일관성 검증 테스트 추가
  - 시간 갭/중복 검증, 적용일자 기반 조회, 모델링되지 않은 날짜 시 명시적 `ValueError`

## ✅ 체크 사항
- [x] 빌드/실행 확인
- [x] 민감 정보 제거
- [x] 테스트 코드 작성 및 통과
- [x] 컨벤션 준수
