### PR TITLE
[Feat] 전세사기 위험도 분석 프록시 및 안전등급 결과 합본 API 추가

### DIFF
--- a/backend/home-risk-check-spring/.env.example
+++ b/backend/home-risk-check-spring/.env.example
@@ -35,6 +35,9 @@ KAKAO_REST_API_KEY=your_kakao_key
 TAAS_API_KEY=your_taas_key
 PUBLIC_DATA_SERVICE_KEY=your_public_data_key
 
+# ────────── FastAPI (위험도 분석 서버) ──────────
+FASTAPI_BASE_URL=http://localhost:8000
+
 # ────────── JWT 키 경로 (운영 전용) ──────────
 # 운영에서 JAR 내부 keys/ 대신 외부 디스크 경로 사용 시 설정
 # JWT_PRIVATE_KEY_PATH=file:/etc/secrets/privatekey.pem

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/controller/RiskAnalysisController.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/controller/RiskAnalysisController.java
@@ -1,0 +1,58 @@
+package hanshin.home_risk_check.riskanalysis.controller;
+
+import hanshin.home_risk_check.global.dto.ApiResponse;
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisRequest;
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisStatusResponse;
+import hanshin.home_risk_check.riskanalysis.service.RiskAnalysisService;
+import hanshin.home_risk_check.user.entity.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/risk-analysis")
+public class RiskAnalysisController {
+
+    private final RiskAnalysisService riskAnalysisService;
+
+    /*
+     * 위험도 분석 요청.
+     * 응답 status: PENDING(접수, taskId로 폴링) 또는 COMPLETED(캐시히트, 즉시 결과)
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<RiskAnalysisStatusResponse>> submit(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestPart("data") RiskAnalysisRequest request,
+            @RequestPart(value = "ledgerFiles", required = false) List<MultipartFile> ledgerFiles,
+            @RequestPart(value = "registryFiles", required = false) List<MultipartFile> registryFiles
+    ) {
+        RiskAnalysisStatusResponse response =
+                riskAnalysisService.submit(currentUser.getUser(), request, ledgerFiles, registryFiles);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(HttpStatus.OK.value(), "위험도 분석 요청 성공", response));
+    }
+
+    /*
+     * 분석 작업 상태/결과 조회 (폴링).
+     * COMPLETED 시 위험도 결과 + 지역 안전등급 합본 반환.
+     */
+    @GetMapping("/{taskId}")
+    public ResponseEntity<ApiResponse<RiskAnalysisStatusResponse>> getStatus(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @PathVariable String taskId
+    ) {
+        RiskAnalysisStatusResponse response =
+                riskAnalysisService.getStatus(currentUser.getUser(), taskId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(HttpStatus.OK.value(), "위험도 분석 상태 조회 성공", response));
+    }
+}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/HugResult.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/HugResult.java
@@ -1,0 +1,17 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/*
+ * HUG 전세보증금 반환보증 심사 결과.
+ * FastAPI hug_result 와 매핑. reason은 가입 불가일 때만 존재.
+ */
+public record HugResult(
+    @JsonProperty("is_eligible")
+    boolean eligible,
+
+    long safeLimit,
+    double coverageRatio,
+    String message,
+    String reason
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskAnalysisRequest.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskAnalysisRequest.java
@@ -1,0 +1,18 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/*
+ * 위험도 분석 요청 (파일 제외 본문).
+ */
+public record RiskAnalysisRequest(
+
+    @Min(value = 0, message = "보증금은 0 이상이어야 합니다.")
+    long deposit,
+
+    @NotBlank(message = "주소는 비어 있을 수 없습니다.")
+    @Size(min = 5, max = 200, message = "주소는 5~200자여야 합니다.")
+    String address
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskAnalysisResult.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskAnalysisResult.java
@@ -1,0 +1,23 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/*
+ * 전세사기 위험도 분석 결과.
+ * FastAPI predict 결과(result)와 매핑.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RiskAnalysisResult(
+    String address,
+    long deposit,
+    long marketPrice,
+    String priceSource,
+    int riskScore,
+    String riskLevel,
+    List<RiskFactor> majorRiskFactors,
+    HugResult hugResult,
+    RiskDetails details,
+    List<String> recommendations,
+    ScoringDetail scoringDetail
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskAnalysisStatusResponse.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskAnalysisStatusResponse.java
@@ -1,0 +1,23 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import hanshin.home_risk_check.safetyscore.domain.score.dto.SafetyScoreResponse;
+import lombok.Builder;
+
+/*
+ * 클라이언트에 내려주는 위험도 분석 상태/결과 응답.
+ *
+ * - PENDING/PROCESSING: status, progress 만 채워짐
+ * - COMPLETED: riskAnalysis + safetyScore
+ * - FAILED: error 채워짐
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RiskAnalysisStatusResponse(
+    String taskId,
+    TaskStatus status,
+    Integer progress,
+    RiskAnalysisResult riskAnalysis,
+    SafetyScoreResponse.Data safetyScore,
+    String error
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskDetails.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskDetails.java
@@ -1,0 +1,21 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/*
+ * 위험도 분석 세부 지표.
+ * FastAPI details 와 매핑.
+ */
+public record RiskDetails(
+    double jeonseRatio,
+    long seniorDebt,
+
+    @JsonProperty("is_illegal_building")
+    boolean illegalBuilding,
+
+    @JsonProperty("is_trust")
+    boolean trust,
+
+    double buildingAge,
+    Integer ownershipDurationMonths
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskFactor.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/RiskFactor.java
@@ -1,0 +1,11 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+/*
+ * 위험 요인 한 건.
+ * FastAPI major_risk_factors[] 의 각 항목과 매핑.
+ */
+public record RiskFactor(
+    String type,
+    String severity,
+    String message
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/ScoringDetail.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/ScoringDetail.java
@@ -1,0 +1,13 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+import java.util.Map;
+
+/*
+ * 점수 산출 내역 (룰 베이스 + ML 하이브리드).
+ * FastAPI scoring_detail 과 매핑.
+ */
+public record ScoringDetail(
+    Integer ruleScore,
+    Double mlScore,
+    Map<String, Object> weights
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/TaskStatus.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/dto/TaskStatus.java
@@ -1,0 +1,11 @@
+package hanshin.home_risk_check.riskanalysis.dto;
+
+/*
+ * 위험도 분석 작업 상태. FastAPI TaskStatus 와 동일.
+ */
+public enum TaskStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/entity/RiskAnalysisHistory.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/entity/RiskAnalysisHistory.java
@@ -1,0 +1,70 @@
+package hanshin.home_risk_check.riskanalysis.entity;
+
+import hanshin.home_risk_check.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+/*
+ * 사용자별 위험도 분석 이력.
+ * 분석이 COMPLETED 된 시점에 핵심 결과를 저장 (마이페이지 분석 이력 조회용).
+ * task_id 유니크로 동일 작업 중복 저장 방지.
+ */
+@Getter
+@Entity
+@Table(
+        name = "risk_analysis_history",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_risk_analysis_task", columnNames = {"task_id"})
+        },
+        indexes = {
+                @Index(name = "idx_risk_analysis_user_created_at", columnList = "user_id, created_at")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class RiskAnalysisHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "task_id", nullable = false, length = 64)
+    private String taskId;
+
+    @Column(name = "address", nullable = false, length = 200)
+    private String address;
+
+    @Column(name = "deposit", nullable = false)
+    private long deposit;
+
+    @Column(name = "risk_score", nullable = false)
+    private int riskScore;
+
+    @Column(name = "risk_level", nullable = false, length = 20)
+    private String riskLevel;
+
+    @Column(name = "created_at", nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RiskAnalysisHistory(User user, String taskId, String address, long deposit, int riskScore, String riskLevel) {
+        this.user = user;
+        this.taskId = taskId;
+        this.address = address;
+        this.deposit = deposit;
+        this.riskScore = riskScore;
+        this.riskLevel = riskLevel;
+    }
+}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/RiskAnalysisApiClient.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/RiskAnalysisApiClient.java
@@ -1,0 +1,162 @@
+package hanshin.home_risk_check.riskanalysis.infra;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import hanshin.home_risk_check.global.exception.BusinessException;
+import hanshin.home_risk_check.global.exception.ErrorCode;
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisResult;
+import hanshin.home_risk_check.riskanalysis.infra.dto.FastApiEnvelope;
+import hanshin.home_risk_check.riskanalysis.infra.dto.PredictAcceptedData;
+import hanshin.home_risk_check.riskanalysis.infra.dto.PredictPollData;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * FastAPI 위험도 분석 서버 호출 클라이언트.
+ *
+ * - POST /predict        : 파일 + 본문을 multipart로 전달, 접수(202) 또는 캐시히트(200)
+ * - GET  /predict/{id}   : 작업 상태/결과 폴링
+ */
+@Slf4j
+@Component
+public class RiskAnalysisApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+
+    public RiskAnalysisApiClient(
+            RestTemplate restTemplate,
+            @Value("${fastapi.base-url}") String baseUrl
+    ) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+        this.objectMapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    /*
+     * 분석 요청 제출.
+     * 캐시히트면 결과가 즉시 반환, 아니면 taskId 발급(202).
+     */
+    public PredictSubmission submitPredict(
+            long deposit,
+            String address,
+            List<MultipartFile> ledgerFiles,
+            List<MultipartFile> registryFiles
+    ) {
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("deposit", String.valueOf(deposit));
+        body.add("address", address);
+        addFiles(body, "ledger_files", ledgerFiles);
+        addFiles(body, "registry_files", registryFiles);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<String> response =
+                    restTemplate.postForEntity(baseUrl + "/predict", entity, String.class);
+
+            // 202: 접수 → taskId / 200: 캐시히트 → 완성 결과
+            if (response.getStatusCode() == HttpStatus.ACCEPTED) {
+                PredictAcceptedData data = readEnvelope(response.getBody(), new TypeReference<>() {});
+                return PredictSubmission.accepted(data.taskId());
+            }
+            RiskAnalysisResult cached = read(response.getBody(), RiskAnalysisResult.class);
+            return PredictSubmission.cacheHit(cached);
+
+        } catch (RestClientException e) {
+            log.error("[FastAPI] /predict 요청 실패: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.EXTERNAL_API_FAILED, e);
+        }
+    }
+
+    /*
+     * 작업 상태/결과 폴링.
+     */
+    public PredictPollData pollPredict(String taskId) {
+        try {
+            ResponseEntity<String> response =
+                    restTemplate.getForEntity(baseUrl + "/predict/" + taskId, String.class);
+            return readEnvelope(response.getBody(), new TypeReference<>() {});
+        } catch (RestClientException e) {
+            log.error("[FastAPI] /predict/{} 폴링 실패: {}", taskId, e.getMessage());
+            throw new BusinessException(ErrorCode.EXTERNAL_API_FAILED, e);
+        }
+    }
+
+    private void addFiles(MultiValueMap<String, Object> body, String partName, List<MultipartFile> files) {
+        if (CollectionUtils.isEmpty(files)) {
+            return;
+        }
+        for (MultipartFile file : files) {
+            body.add(partName, toResource(file));
+        }
+    }
+
+    private Resource toResource(MultipartFile file) {
+        try {
+            byte[] bytes = file.getBytes();
+            String filename = file.getOriginalFilename();
+            return new ByteArrayResource(bytes) {
+                @Override
+                public String getFilename() {
+                    return filename;
+                }
+            };
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, e);
+        }
+    }
+
+    private <T> T readEnvelope(String json, TypeReference<FastApiEnvelope<T>> typeRef) {
+        try {
+            FastApiEnvelope<T> envelope = objectMapper.readValue(json, typeRef);
+            return envelope.data();
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.EXTERNAL_API_FAILED, e);
+        }
+    }
+
+    private <T> T read(String json, Class<T> type) {
+        try {
+            return objectMapper.readValue(json, type);
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.EXTERNAL_API_FAILED, e);
+        }
+    }
+
+    /*
+     * 제출 결과: 캐시히트(완성 결과) 또는 접수(taskId) 중 하나.
+     */
+    public record PredictSubmission(boolean cacheHit, String taskId, RiskAnalysisResult cachedResult) {
+        public static PredictSubmission accepted(String taskId) {
+            return new PredictSubmission(false, taskId, null);
+        }
+
+        public static PredictSubmission cacheHit(RiskAnalysisResult result) {
+            return new PredictSubmission(true, null, result);
+        }
+    }
+}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/dto/FastApiEnvelope.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/dto/FastApiEnvelope.java
@@ -1,0 +1,10 @@
+package hanshin.home_risk_check.riskanalysis.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/*
+ * FastAPI 공통 응답 래퍼 { meta, data }.
+ * meta는 사용하지 않으므로 data만 추출. 미정의 필드는 무시.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FastApiEnvelope<T>(T data) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/dto/PredictAcceptedData.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/dto/PredictAcceptedData.java
@@ -1,0 +1,16 @@
+package hanshin.home_risk_check.riskanalysis.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import hanshin.home_risk_check.riskanalysis.dto.TaskStatus;
+
+/*
+ * FastAPI POST /predict 접수(202) data.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PredictAcceptedData(
+    String taskId,
+    TaskStatus status,
+    String cacheKey,
+    String pollUrl,
+    Integer estimatedSeconds
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/dto/PredictPollData.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/infra/dto/PredictPollData.java
@@ -1,0 +1,20 @@
+package hanshin.home_risk_check.riskanalysis.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisResult;
+import hanshin.home_risk_check.riskanalysis.dto.TaskStatus;
+
+/*
+ * FastAPI GET /predict/{task_id} data.
+ * - COMPLETED: result 채워짐
+ * - FAILED: error 채워짐
+ * - PENDING/PROCESSING: progress 만
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PredictPollData(
+    String taskId,
+    TaskStatus status,
+    Integer progress,
+    RiskAnalysisResult result,
+    String error
+) {}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/repository/RiskAnalysisHistoryRepository.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/repository/RiskAnalysisHistoryRepository.java
@@ -1,0 +1,8 @@
+package hanshin.home_risk_check.riskanalysis.repository;
+
+import hanshin.home_risk_check.riskanalysis.entity.RiskAnalysisHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RiskAnalysisHistoryRepository extends JpaRepository<RiskAnalysisHistory, Long> {
+    boolean existsByTaskId(String taskId);
+}

--- a/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/service/RiskAnalysisService.java
+++ b/backend/home-risk-check-spring/src/main/java/hanshin/home_risk_check/riskanalysis/service/RiskAnalysisService.java
@@ -1,0 +1,123 @@
+package hanshin.home_risk_check.riskanalysis.service;
+
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisRequest;
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisResult;
+import hanshin.home_risk_check.riskanalysis.dto.RiskAnalysisStatusResponse;
+import hanshin.home_risk_check.riskanalysis.dto.TaskStatus;
+import hanshin.home_risk_check.riskanalysis.entity.RiskAnalysisHistory;
+import hanshin.home_risk_check.riskanalysis.infra.RiskAnalysisApiClient;
+import hanshin.home_risk_check.riskanalysis.infra.RiskAnalysisApiClient.PredictSubmission;
+import hanshin.home_risk_check.riskanalysis.infra.dto.PredictPollData;
+import hanshin.home_risk_check.riskanalysis.repository.RiskAnalysisHistoryRepository;
+import hanshin.home_risk_check.safetyscore.domain.score.dto.SafetyScoreResponse;
+import hanshin.home_risk_check.safetyscore.domain.score.service.SafetyScoreService;
+import hanshin.home_risk_check.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+/*
+ * 전세사기 위험도 분석 흐름 조정.
+ *
+ * - submit: FastAPI에 분석 요청 전달. 캐시히트면 즉시 합본 결과, 아니면 taskId 발급.
+ * - getStatus: FastAPI 폴링. 완료 시 안전등급을 함께 계산해 합본 + 이력 저장.
+ *
+ * 전세사기 위험도와 안전등급 결과를 하나의 응답으로 생성
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RiskAnalysisService {
+
+    private final RiskAnalysisApiClient apiClient;
+    private final SafetyScoreService safetyScoreService;
+    private final RiskAnalysisHistoryRepository historyRepository;
+
+    public RiskAnalysisStatusResponse submit(
+            User user,
+            RiskAnalysisRequest request,
+            List<MultipartFile> ledgerFiles,
+            List<MultipartFile> registryFiles
+    ) {
+        PredictSubmission submission = apiClient.submitPredict(
+                request.deposit(), request.address(), ledgerFiles, registryFiles
+        );
+
+        // 캐시히트: 이미 완료된 결과 → 안전등급 합쳐 즉시 반환 (taskId 없음 → 이력 저장 안 함)
+        if (submission.cacheHit()) {
+            return buildCompleted(null, submission.cachedResult(), user);
+        }
+
+        // 접수: 폴링용 taskId 반환
+        return RiskAnalysisStatusResponse.builder()
+                .taskId(submission.taskId())
+                .status(TaskStatus.PENDING)
+                .progress(0)
+                .build();
+    }
+
+    public RiskAnalysisStatusResponse getStatus(User user, String taskId) {
+        PredictPollData poll = apiClient.pollPredict(taskId);
+
+        return switch (poll.status()) {
+            case COMPLETED -> buildCompleted(taskId, poll.result(), user);
+            case FAILED -> RiskAnalysisStatusResponse.builder()
+                    .taskId(taskId)
+                    .status(TaskStatus.FAILED)
+                    .progress(poll.progress())
+                    .error(poll.error())
+                    .build();
+            default -> RiskAnalysisStatusResponse.builder()
+                    .taskId(taskId)
+                    .status(poll.status())
+                    .progress(poll.progress())
+                    .build();
+        };
+    }
+
+    /* 위험도 결과 + 안전등급 합본 구성. taskId가 있으면 이력 저장. */
+    private RiskAnalysisStatusResponse buildCompleted(String taskId, RiskAnalysisResult result, User user) {
+        SafetyScoreResponse.Data safetyScore = resolveSafetyScore(result.address());
+        saveHistoryIfAbsent(user, taskId, result);
+
+        return RiskAnalysisStatusResponse.builder()
+                .taskId(taskId)
+                .status(TaskStatus.COMPLETED)
+                .progress(100)
+                .riskAnalysis(result)
+                .safetyScore(safetyScore)
+                .build();
+    }
+
+    /* 안전등급 계산 실패는 위험도 결과 반환을 막지 않는다 (부분 실패 허용). */
+    private SafetyScoreResponse.Data resolveSafetyScore(String address) {
+        try {
+            return safetyScoreService.calculateSafetyScore(address).getData();
+        } catch (Exception e) {
+            log.warn("안전등급 계산 실패 (위험도 결과만 반환) - 주소: {}, 원인: {}", address, e.getMessage());
+            return null;
+        }
+    }
+
+    private void saveHistoryIfAbsent(User user, String taskId, RiskAnalysisResult result) {
+        if (taskId == null || historyRepository.existsByTaskId(taskId)) {
+            return;
+        }
+        try {
+            historyRepository.save(RiskAnalysisHistory.builder()
+                    .user(user)
+                    .taskId(taskId)
+                    .address(result.address())
+                    .deposit(result.deposit())
+                    .riskScore(result.riskScore())
+                    .riskLevel(result.riskLevel())
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            // 동시 폴링으로 이미 저장됨 — 무시
+            log.debug("이미 저장된 분석 이력: taskId={}", taskId);
+        }
+    }
+}

--- a/backend/home-risk-check-spring/src/main/resources/application.properties
+++ b/backend/home-risk-check-spring/src/main/resources/application.properties
@@ -37,6 +37,9 @@ public-data.service-key=${PUBLIC_DATA_SERVICE_KEY:}
 kakao.rest-api-key=${KAKAO_REST_API_KEY:}
 taas.api-key=${TAAS_API_KEY:}
 
+# ────────── FastAPI (위험도 분석) ──────────
+fastapi.base-url=${FASTAPI_BASE_URL:http://localhost:8000}
+
 # ────────── 파일 저장소 (AWS S3) ──────────
 aws.s3.region=${AWS_REGION:ap-northeast-2}
 aws.s3.bucket=${AWS_S3_BUCKET:}


### PR DESCRIPTION
<!-- 템플릿 설명
1. Pull Request 템플릿의 제목은 다음과 같이 작성합니다.
예시) [Feature] 로그인 구현

2. (내용) 부분을 수정 또는 추가해 주세요.
-->

<!-- 작업한 기능에 대한 간단한 설명을 작성해주세요. -->
🔎 개요
- 전세사기 위험도 분석 프록시 및 안전등급 결과 합본 API 추가

<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
📑 작업 내용
- riskanalysis 도메인 신설: FastAPI /predict 프록시 (비동기 + 폴링)
  - POST /api/risk-analysis: multipart 파일 메모리 스트리밍 전달, 인증 필요
  - GET /api/risk-analysis/{taskId}: 폴링, 완료 시 위험도+안전등급 합본 반환
- RiskAnalysisApiClient: FastAPI 호출 (snake_case 전용 ObjectMapper)
- 완료 시 SafetyScoreService 호출해 지역 안전등급 합본
- RiskAnalysisHistory로 사용자별 분석 이력 저장 (taskId 유니크, 중복 방지)
- 안전등급 계산 실패는 위험도 결과 반환을 막지 않음 (부분 실패 허용)

<!-- 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
‼️ 기타 사항
- **`.env`에 `FASTAPI_BASE_URL` 추가** (없으면 default `http://localhost:8000`)
- **FastAPI 서버 필수** — `/api/risk-analysis`는 FastAPI `/predict` 프록시. predict 응답 스키마 변경 시 스프링 DTO도 수정
- **인증 필수** — 두 엔드포인트 모두 JWT 필요
- **사용 흐름**: POST → (PENDING이면) GET 폴링 → COMPLETED 시 위험도+안전등급 합본

✅ 체크 사항
- [x] 빌드/실행 확인
- [x] 민감 정보 제거
- [ ] 테스트 코드 작성 및 통과
- [x] 컨벤션 준수

<!-- 작업한 기능과 관련된 이슈가 있다면 작성해주세요.
해당 pr merge 시 이슈 close
-->
📎 관련 이슈
- closes #이슈번호